### PR TITLE
AU-11: Fixed a bug where a general ORU-R01 was thrown out during proc…

### DIFF
--- a/api/src/main/java/org/openmrs/module/pcslabinterface/LabORUR01Handler.java
+++ b/api/src/main/java/org/openmrs/module/pcslabinterface/LabORUR01Handler.java
@@ -90,33 +90,6 @@ public class LabORUR01Handler extends ORUR01Handler {
 	);
 
 	/**
-	 * decide whether this handler can handle the given message
-	 *
-	 * @return fitness of this handler for the given message
-	 * @should ignore messages originating from anywhere but REFPACS or PCS
-	 */
-	public boolean canProcess(Message message) {
-		if (message != null && "ORU_R01".equals(message.getName())) {
-			ORU_R01 oru = (ORU_R01) message;
-			MSH msh = getMSH(oru);
-			String sendingApplication = msh.getSendingApplication().getNamespaceID().getValue();
-
-			// TODO remove these tests when we are ready to handle all ORU^R01 messages
-			// check for special indicators
-
-            log.debug(oru.getMSH()+" Sending application is: "+ sendingApplication);
-
-            if (!StringUtils.hasLength(sendingApplication))
-				return false;
-
-			if (allowedSendingApps.contains(sendingApplication.toLowerCase()))
-				return true;
-		}
-
-		return false;
-	}
-
-	/**
 	 * Processes an ORU R01 event message
 	 *
 	 * @should process messages with PCSLabPlus formatted PID segments
@@ -140,7 +113,7 @@ public class LabORUR01Handler extends ORUR01Handler {
 			ORU_R01 oru = (ORU_R01) message;
 
 			// if this is consumable, consume it
-			if (canProcess(oru))
+			if (isLabMessage(oru))
 				response = processLabORU_R01(oru);
 
 				// otherwise, let the ORUR01Handler class do the work
@@ -1287,4 +1260,29 @@ public class LabORUR01Handler extends ORUR01Handler {
 		return p;
 	}
 
+    /**
+     * LabORUR01Handler#isLabMessage checks whether a message is a Lab message or not.
+     * @param message
+     * @return  true or false
+     */
+    public boolean isLabMessage(Message message) {
+        if (message != null && "ORU_R01".equals(message.getName())) {
+            ORU_R01 oru = (ORU_R01) message;
+            MSH msh = getMSH(oru);
+            String sendingApplication = msh.getSendingApplication().getNamespaceID().getValue();
+
+            // TODO remove these tests when we are ready to handle all ORU^R01 messages
+            // check for special indicators
+
+            log.debug(oru.getMSH()+" Sending application is: "+ sendingApplication);
+
+            if (!StringUtils.hasLength(sendingApplication))
+                return false;
+
+            if (allowedSendingApps.contains(sendingApplication.toLowerCase()))
+                return true;
+        }
+
+        return false;
+    }
 }

--- a/api/src/test/java/org/openmrs/module/pcslabinterface/LabORUR01HandlerTest.java
+++ b/api/src/test/java/org/openmrs/module/pcslabinterface/LabORUR01HandlerTest.java
@@ -114,7 +114,7 @@ public class LabORUR01HandlerTest extends BaseModuleContextSensitiveTest {
 	 * @see LabORUR01Handler#canProcess(ca.uhn.hl7v2.model.Message)
 	 */
 	@Test
-	public void canProcess_shouldIgnoreMessagesOriginatingFromAnywhereButREFPACSOrPCS() throws Exception {
+	public void isLabMessage_shouldIgnoreMessagesOriginatingFromAnywhereButREFPACSOrPCS() throws Exception {
 		String hl7string = "MSH|^~\\&|PCSLABPLUS|PCS|HL7LISTENER|AMRS.ELD|20080226102656||ORU^R01|ABC101083591|P|2.5|1||||||||16^AMRS.ELD.FORMID\r"
 				+ "PID|||12345^^M10^AMRS^MR||John3^Doe^\r"
 				+ "PV1||O|1^Unknown Location||||1^Super User (1-8)|||||||||||||||||||||||||||||||||||||20080212|||||||V\r"
@@ -125,7 +125,7 @@ public class LabORUR01HandlerTest extends BaseModuleContextSensitiveTest {
 
 		Message hl7message = parser.parse(hl7string);
 
-		assertTrue(new LabORUR01Handler().canProcess(hl7message));
+		assertTrue(new LabORUR01Handler().isLabMessage(hl7message));
 
 		hl7string = "MSH|^~\\&|REFPACS|IU|HL7LISTENER|AMRS.ELD|20080226102656||ORU^R01|ABC101083591|P|2.5|1||||||||16^AMRS.ELD.FORMID\r"
 				+ "PID|||12345^^M10^AMRS^MR||John3^Doe^\r"
@@ -137,7 +137,7 @@ public class LabORUR01HandlerTest extends BaseModuleContextSensitiveTest {
 
 		hl7message = parser.parse(hl7string);
 
-		assertTrue(new LabORUR01Handler().canProcess(hl7message));
+		assertTrue(new LabORUR01Handler().isLabMessage(hl7message));
 
 		hl7string = "MSH|^~\\&|FORMENTRY|AMPATH|HL7LISTENER|AMRS.ELD|20080226102656||ORU^R01|ABC101083591|P|2.5|1||||||||16^AMRS.ELD.FORMID\r"
 				+ "PID|||12345^^M10^AMRS^MR||John3^Doe^\r"
@@ -149,7 +149,7 @@ public class LabORUR01HandlerTest extends BaseModuleContextSensitiveTest {
 
 		hl7message = parser.parse(hl7string);
 
-		assertFalse(new LabORUR01Handler().canProcess(hl7message));
+		assertFalse(new LabORUR01Handler().isLabMessage(hl7message));
 	}
 
 	/**


### PR DESCRIPTION
…essing.

LabORUR01Handler overrode canProcess method which was implemented to only return true for messages
coming from lab. However the Lab processor falls back to ORUR01 general handler if the message is not from Lab.
This was not happening because when the service calls canProcess(), the subclass version was being called and
it returned false. The method has been renamed to isLabMessage and defer the test to super class.
